### PR TITLE
Use only the HSL-specific endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@ This is a custom component for Home Assistant, which adds a single stop (bus
 or tram stop, train or metro platform) from Helsinki Region Transport
 (Helsingin seudun liikenne, HSL) as a Home Assistant sensor.
 
-Currently rail stations do not work reliably - follow [issue 33](https://github.com/Mallonbacka/custom-component-digitransit/issues/33)
-for updates.
-
 You can add a stop using either:
 
 - The stop number, which you can find on a sign at the

--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -23,7 +23,7 @@ class DigitransitGraphQLWrapper:
         """Create a new instance with an API key."""
         self.api_key = api_key
         self.hass = hass
-        self.client = GraphqlClient(endpoint=f"https://api.digitransit.fi/routing/v1/routers/finland/index/graphql?digitransit-subscription-key={self.api_key}")
+        self.client = GraphqlClient(endpoint=f"https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql?digitransit-subscription-key={self.api_key}")
 
     def sync_test_api_key(self):
         """Try to list feeds to see if the API key works."""
@@ -80,7 +80,6 @@ class DigitransitGraphQLWrapper:
         """Get stop times from a saved GTFS id."""
         query = """{ stop(id: "$stop_id") { name, stoptimesWithoutPatterns { scheduledDeparture, realtimeDeparture, departureDelay, realtime, realtimeState, serviceDay, headsign, trip { routeShortName } } } }"""
         results = self.client.execute(query=query.replace("$stop_id", gtfs_id))
-        LOGGER.debug(results)
         return results
 
     async def get_stop_data(self, gtfs_id):


### PR DESCRIPTION
It seems like the general "Finland" endpoint is missing live train information, while the same request pointed at the HSL endpoint returns train departures.

This change will make all requests use the HSL-specific endpoint, since other limitations currently exist which mean that this is HSL-only for now. If these get fixed in the future, he endpoint should be selectable in the interface.

Fixes #33