### PR TITLE
Add support for Waltti stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 This is a custom component for Home Assistant, which adds a single stop (bus
 or tram stop, train or metro platform) from Helsinki Region Transport
-(Helsingin seudun liikenne, HSL) as a Home Assistant sensor.
+(Helsingin seudun liikenne, HSL, Helsingforsregionens trafik, HRT) as a
+Home Assistant sensor.
 
 You can add a stop using either:
 
 - The stop number, which you can find on a sign at the
 stop or from the journey planner (reittiopas). For example, for trams from
 Länsiterminaali T1 going towards central Helsinki, you'd use H0236. For
-platform 1 at Tapiola bus station, you'd use E2187.
+platform 1 at Tapiola bus station, you'd use E2187. At present this doesn't
+work for non-HSL regions.
 - The GTFS identifier of the stop. This is useful if two stops
 share a single stop number. You can find this URL encoded inside the address
 of the journey planner page for the stop. For example, Alberganesplanadi
@@ -21,9 +23,7 @@ on [the Digitransit website](https://digitransit.fi/en/developers/api-registrati
 ## Pre-release warning
 
 The basic functionality works, but this isn't yet ready for wider use, so
-use this at your own risk. One key limitation at present is that some
-HSL-specific arguments are hard-coded, whereas the API supports all
-Digitransit-supported areas of Finland.
+use this at your own risk.
 
 Another limitation is that stations are not currently supported, only
 stops. This means you can't monitor all departures from a station

--- a/custom_components/digitransit/__init__.py
+++ b/custom_components/digitransit/__init__.py
@@ -24,7 +24,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator = DigitransitDataUpdateCoordinator(
         hass=hass,
-        client=DigitransitGraphQLWrapper(entry.data['digitransit_api_key'], hass),
+        client=DigitransitGraphQLWrapper(
+            # Versions 0.2.2 and earlier supported only HSL, so if the region is not set, assume it is HSL
+            entry.data['digitransit_api_key'], entry.data.get('data_region', "hsl"), hass),
     )
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -32,6 +32,7 @@ class DigitransitGraphQLWrapper:
         self.client = GraphqlClient(endpoint=self.endpoint())
 
     def endpoint(self):
+        """Get the right endpoint for the selected region, with the API key ready-appended."""
         match self.data_region:
             case "hsl":
                 return f"https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql?digitransit-subscription-key={self.api_key}"

--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -4,26 +4,41 @@ import requests
 
 from .const import LOGGER
 
+
 class DigitransitGraphQLError(Exception):
     """Non-specific error."""
+
 
 class DigitransitNotAuthenticatedError(DigitransitGraphQLError):
     """Authentication failed."""
 
+
 class DigitransitNoStopFoundError(DigitransitGraphQLError):
     """Zero matching stops returned."""
+
 
 class DigitransitMultipleStopsFoundError(DigitransitGraphQLError):
     """Too many possible stops found."""
 
+
 class DigitransitGraphQLWrapper:
     """An API client which wraps around a simple GraphQL client."""
 
-    def __init__(self, api_key, hass) -> None:
+    def __init__(self, api_key, data_region, hass) -> None:
         """Create a new instance with an API key."""
         self.api_key = api_key
         self.hass = hass
-        self.client = GraphqlClient(endpoint=f"https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql?digitransit-subscription-key={self.api_key}")
+        self.data_region = data_region
+        self.client = GraphqlClient(endpoint=self.endpoint())
+
+    def endpoint(self):
+        match self.data_region:
+            case "hsl":
+                return f"https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql?digitransit-subscription-key={self.api_key}"
+            case "waltti":
+                return f"https://api.digitransit.fi/routing/v1/routers/waltti/index/graphql?digitransit-subscription-key={self.api_key}"
+            case "digitransit":
+                return f"https://api.digitransit.fi/routing/v1/routers/finland/index/graphql?digitransit-subscription-key={self.api_key}"
 
     def sync_test_api_key(self):
         """Try to list feeds to see if the API key works."""
@@ -43,12 +58,12 @@ class DigitransitGraphQLWrapper:
     def sync_get_stop_name_and_id_by_code(self, stop_code):
         """Find a stop name and ID from a stop code or name."""
         query = """query stopQuery($stop_code: String) { stops(name: $stop_code, feeds: ["HSL"], maxResults: 2){name,desc,code,platformCode,gtfsId}}"""
-        variables = { "stop_code": stop_code }
+        variables = {"stop_code": stop_code}
         results = self.client.execute(query=query, variables=variables)
-        if(len(results['data']['stops']) == 0):
+        if (len(results['data']['stops']) == 0):
             # No results
             raise DigitransitNoStopFoundError
-        elif(len(results['data']['stops']) > 1):
+        elif (len(results['data']['stops']) > 1):
             # Too many results
             raise DigitransitMultipleStopsFoundError
         else:
@@ -64,7 +79,7 @@ class DigitransitGraphQLWrapper:
         """Find a stop name and ID from a GTFS id."""
         query = f"""{{ stop(id: "{gtfs_id}"){{name,code,platformCode,gtfsId}}}}"""
         results = self.client.execute(query=query)
-        if(len(results['data']['stop']) == {}):
+        if (len(results['data']['stop']) == {}):
             # No results
             raise DigitransitNoStopFoundError
         else:

--- a/custom_components/digitransit/translations/en.json
+++ b/custom_components/digitransit/translations/en.json
@@ -5,6 +5,7 @@
                 "description": "You'll need a Digitransit API key to get started, get one from https://digitransit.fi",
                 "data": {
                     "digitransit_api_key": "Digitransit API key",
+                    "data_region": "Transport provider",
                     "search_type": "Find a stop",
                     "search_term": "Stop code"
                 }
@@ -21,8 +22,15 @@
     "selector": {
         "search_types": {
             "options": {
-                "stop_code": "by stop code (e.g. H0086)",
-                "stop_gtfs_id": "by GTFS ID (e.g. HSL:1392551)"
+                "stop_code": "by stop code (e.g. H0086, only supported by HSL at present)",
+                "stop_gtfs_id": "by GTFS ID (e.g. HSL:1392551 or tampere:0812)"
+            }
+        },
+        "data_regions": {
+            "options": {
+                "hsl": "HSL",
+                "waltti": "Waltti",
+                "digitransit": "Other (via Finland-wide Digitransit API)"
             }
         }
     }


### PR DESCRIPTION
Closes #54 

There's some outstanding work which will be covered separately, refactoring the single sep config into two steps, so that users are only asked for a supported stop ID format depending on their region (this needs a little more investigation, to see whether alternative formats can be accepted for other regions). 