### PR TITLE
Add config migration to set HSL as data_region

### DIFF
--- a/custom_components/digitransit/config_flow.py
+++ b/custom_components/digitransit/config_flow.py
@@ -18,7 +18,7 @@ from .graphql_wrapper import (
 class DigitransitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Blueprint."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self,

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Digitransit",
     "filename": "digitransit.zip",
     "hide_default_branch": true,
-    "homeassistant": "2023.8.0",
+    "homeassistant": "2024.3.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.8.2
-homeassistant==2023.8.0
+homeassistant==2024.3.0
 pip>=21.0,<24.2
 ruff==0.5.4
 


### PR DESCRIPTION
When I merged https://github.com/Mallonbacka/custom-component-digitransit/pull/55, I hardcoded a fallback for cases when data_region was missing. This was intended for situations where the integration was set up before v0.3.0, when this value wasn't set. 

A more sustainable solution would to automatically migrate the configuration. This PR adds that functionality. If the data_region is already set (so the integration was set up with v0.3.0), the value is persisted, if it is unset, it will be set to HSL. 

This also removes the previously hardcoded fallback value. 

As the current implementation of config entry migration changed in Home Assistant 2024.3, this now becomes the minimal supported version. 