### PR TITLE
Update Python in development to 3.12

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "ludeeus/integration_blueprint",
-    "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12-bullseye",
     "postCreateCommand": "scripts/setup",
     "forwardPorts": [
         8123

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
         - name: "Set up Python"
           uses: actions/setup-python@v5.1.1
           with:
-            python-version: "3.11"
+            python-version: "3.12"
             cache: "pip"
 
         - name: "Install requirements"


### PR DESCRIPTION
The minimum supported version of Home Assistant was upgraded to 2024.3 in #59 , which no longer supports Python 3.11. This upgrades both the devcontainer and the GitHub Action for linting to 3.12. 