### PR TITLE
Remove feed from stop name search

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ You can add a stop using either:
 - The stop number, which you can find on a sign at the
 stop or from the journey planner (reittiopas). For example, for trams from
 Länsiterminaali T1 going towards central Helsinki, you'd use H0236. For
-platform 1 at Tapiola bus station, you'd use E2187. At present this doesn't
-work for non-HSL regions.
+platform 1 at Tapiola bus station, you'd use E2187. This won't work if
+two stops have the same code.
 - The GTFS identifier of the stop. This is useful if two stops
 share a single stop number. You can find this URL encoded inside the address
 of the journey planner page for the stop. For example, Alberganesplanadi

--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -58,7 +58,7 @@ class DigitransitGraphQLWrapper:
 
     def sync_get_stop_name_and_id_by_code(self, stop_code):
         """Find a stop name and ID from a stop code or name."""
-        query = """query stopQuery($stop_code: String) { stops(name: $stop_code, feeds: ["HSL"], maxResults: 2){name,desc,code,platformCode,gtfsId}}"""
+        query = """query stopQuery($stop_code: String) { stops(name: $stop_code, maxResults: 2){name,desc,code,platformCode,gtfsId}}"""
         variables = {"stop_code": stop_code}
         results = self.client.execute(query=query, variables=variables)
         if (len(results['data']['stops']) == 0):
@@ -78,7 +78,8 @@ class DigitransitGraphQLWrapper:
 
     def sync_get_stop_name_and_id_by_gtfs(self, gtfs_id):
         """Find a stop name and ID from a GTFS id."""
-        query = f"""{{ stop(id: "{gtfs_id}"){{name,code,platformCode,gtfsId}}}}"""
+        query = f"""{{ stop(id: "{gtfs_id}
+                            "){{name,code,platformCode,gtfsId}}}}"""
         results = self.client.execute(query=query)
         if (len(results['data']['stop']) == {}):
             # No results

--- a/custom_components/digitransit/translations/en.json
+++ b/custom_components/digitransit/translations/en.json
@@ -14,7 +14,7 @@
         "error": {
             "auth": "API key seems wrong.",
             "no_stop_found": "Stop not found. Check that you're giving the stop code, such as H0236.",
-            "too_many_stops": "Multiple possible stops identified. If possible, please search using the stop code, such as H0236.",
+            "too_many_stops": "Multiple stops with the same code found. Try using the GTFS ID instead. You can find this from the journey planner URL.",
             "connection": "Unable to connect to the server.",
             "unknown": "Unknown error occurred."
         }
@@ -22,7 +22,7 @@
     "selector": {
         "search_types": {
             "options": {
-                "stop_code": "by stop code (e.g. H0086, only supported by HSL at present)",
+                "stop_code": "by stop code (e.g. H0086)",
                 "stop_gtfs_id": "by GTFS ID (e.g. HSL:1392551 or tampere:0812)"
             }
         },


### PR DESCRIPTION
The hardcoded feed value when searching for a stop by code prevented it working for non-HSL searches.

This removes the value and also clarifies the instructions for finding by code or by GTFS ID as required. 