### PR TITLE
Remove "brands" exception from Hassfest validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,5 +33,3 @@ jobs:
           uses: "hacs/action@main"
           with:
             category: "integration"
-            # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-            ignore: "brands"


### PR DESCRIPTION
A brand was added to the CDN-served assets in https://github.com/home-assistant/brands/pull/5706, so this ignore key is no longer necessary. 