### PR TITLE
Use transport mode icon where available

### DIFF
--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -95,7 +95,7 @@ class DigitransitGraphQLWrapper:
 
     def sync_get_stop_data(self, gtfs_id):
         """Get stop times from a saved GTFS id."""
-        query = """{ stop(id: "$stop_id") { name, stoptimesWithoutPatterns { scheduledDeparture, realtimeDeparture, departureDelay, realtime, realtimeState, serviceDay, headsign, trip { routeShortName } } } }"""
+        query = """{ stop(id: "$stop_id") { name, vehicleMode, stoptimesWithoutPatterns { scheduledDeparture, realtimeDeparture, departureDelay, realtime, realtimeState, serviceDay, headsign, trip { routeShortName } } } }"""
         results = self.client.execute(query=query.replace("$stop_id", gtfs_id))
         return results
 

--- a/custom_components/digitransit/sensor.py
+++ b/custom_components/digitransit/sensor.py
@@ -43,8 +43,9 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        departures = self.coordinator.data.get("data").get("stop").get("stoptimesWithoutPatterns")
-        if(len(departures) > 0):
+        departures = self.coordinator.data.get("data").get(
+            "stop").get("stoptimesWithoutPatterns")
+        if (len(departures) > 0):
             return departureToNumberOfMinutes(departures[0])
         else:
             return None
@@ -57,14 +58,29 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Attributes contain a list of the next few departures."""
-        departure_list = self.coordinator.data.get("data").get("stop").get("stoptimesWithoutPatterns")
+        departure_list = self.coordinator.data.get(
+            "data").get("stop").get("stoptimesWithoutPatterns")
         departure_list = list(map(formatDepartureRow, departure_list))
-        return { "departures": departure_list }
+        return {"departures": departure_list}
 
     @property
     def icon(self):
-        """Icon is always a bus."""
-        return "mdi:bus"
+        """Icon reflects the transport mode, but falls back to a bus."""
+        vehicle_mode = self.coordinator.data.get(
+            "data").get("stop").get("vehicleMode")
+        match vehicle_mode.lower():
+            case "bus":
+                return "mdi:bus"
+            case "ferry":
+                return "mdi:ferry"
+            case "rail":
+                return "mdi:train-variant"
+            case "subway":
+                return "mdi:subway"
+            case "tram":
+                return "mdi:tram"
+            case _:
+                return "mdi:bus"
 
     @property
     def name(self):


### PR DESCRIPTION
So far icons have always been busses. This updates them to use the vehicleMode returned by the API to show an icon specific to the transport mode. The bus is the default for stops which return 'null'. 