### PR TITLE
Remove 'device' record

### DIFF
--- a/custom_components/digitransit/__init__.py
+++ b/custom_components/digitransit/__init__.py
@@ -3,11 +3,13 @@
 For more details about this integration, please refer to
 https://github.com/ludeeus/digitransit
 """
+
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from .graphql_wrapper import DigitransitGraphQLWrapper
 from .const import DOMAIN, LOGGER
@@ -25,7 +27,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinator = DigitransitDataUpdateCoordinator(
         hass=hass,
         client=DigitransitGraphQLWrapper(
-            entry.data['digitransit_api_key'], entry.data['data_region'], hass),
+            entry.data["digitransit_api_key"], entry.data["data_region"], hass
+        ),
     )
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await coordinator.async_config_entry_first_refresh()
@@ -51,21 +54,25 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
 
 async def async_migrate_entry(hass, entry):
     """Migrate config to latest version."""
-    LOGGER.debug("Migrating configuration from version %s",
-                 entry.version)
+    LOGGER.debug("Migrating configuration from version %s", entry.version)
 
     if entry.version > 1:
         return False
 
     if entry.version == 1:
         new_data = {**entry.data}
-        new_data['data_region'] = entry.data.get('data_region', "hsl")
+        new_data["data_region"] = entry.data.get("data_region", "hsl")
         pass
 
-    hass.config_entries.async_update_entry(
-        entry, data=new_data, version=2)
+    hass.config_entries.async_update_entry(entry, data=new_data, version=2)
 
-    LOGGER.debug(
-        "Migration to configuration version %s successful", entry.version)
+    LOGGER.debug("Migration to configuration version %s successful", entry.version)
 
+    return True
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
     return True

--- a/custom_components/digitransit/entity.py
+++ b/custom_components/digitransit/entity.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN, NAME, VERSION
+from .const import ATTRIBUTION
 from .coordinator import DigitransitDataUpdateCoordinator
 
 

--- a/custom_components/digitransit/entity.py
+++ b/custom_components/digitransit/entity.py
@@ -1,4 +1,5 @@
 """DigitransitEntity class."""
+
 from __future__ import annotations
 
 from homeassistant.helpers.entity import DeviceInfo
@@ -6,6 +7,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, DOMAIN, NAME, VERSION
 from .coordinator import DigitransitDataUpdateCoordinator
+
 
 class DigitransitEntity(CoordinatorEntity):
     """A single configured instance of the component."""
@@ -16,9 +18,3 @@ class DigitransitEntity(CoordinatorEntity):
         """Initialize."""
         super().__init__(coordinator)
         self._attr_unique_id = coordinator.config_entry.entry_id
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
-            name=NAME,
-            model=VERSION,
-            manufacturer=NAME,
-        )


### PR DESCRIPTION
The integration was creating a meaningless 'device' record which wrapped the sensor. This can be removed safely. 

It seems as though this won't actually remove the device until the integration is removed and re-added. This change also allows users to manually remove the device record. 