### PR TITLE
Don't save the departures list in history

### DIFF
--- a/custom_components/digitransit/sensor.py
+++ b/custom_components/digitransit/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for digitransit."""
+
 from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
@@ -31,6 +32,8 @@ async def async_setup_entry(hass, entry, async_add_devices):
 class DigitransitSensor(DigitransitEntity, SensorEntity):
     """digitransit Sensor class."""
 
+    _unrecorded_attributes = frozenset({"departures"})
+
     def __init__(
         self,
         coordinator: DigitransitDataUpdateCoordinator,
@@ -43,9 +46,12 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the native value of the sensor."""
-        departures = self.coordinator.data.get("data").get(
-            "stop").get("stoptimesWithoutPatterns")
-        if (len(departures) > 0):
+        departures = (
+            self.coordinator.data.get("data")
+            .get("stop")
+            .get("stoptimesWithoutPatterns")
+        )
+        if len(departures) > 0:
             return departureToNumberOfMinutes(departures[0])
         else:
             return None
@@ -58,16 +64,18 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Attributes contain a list of the next few departures."""
-        departure_list = self.coordinator.data.get(
-            "data").get("stop").get("stoptimesWithoutPatterns")
+        departure_list = (
+            self.coordinator.data.get("data")
+            .get("stop")
+            .get("stoptimesWithoutPatterns")
+        )
         departure_list = list(map(formatDepartureRow, departure_list))
         return {"departures": departure_list}
 
     @property
     def icon(self):
         """Icon reflects the transport mode, but falls back to a bus."""
-        vehicle_mode = self.coordinator.data.get(
-            "data").get("stop").get("vehicleMode")
+        vehicle_mode = self.coordinator.data.get("data").get("stop").get("vehicleMode")
         match vehicle_mode.lower():
             case "bus":
                 return "mdi:bus"


### PR DESCRIPTION
This component has been saving the complete list of upcoming departures in history. I consider this a bug, since I can't come up with a use for the historical data. 

This change adds the `departures` list as an excluded key from the recorder. Recording the overall state is unchanged. 