### PR TITLE
Make attributes' departure times timezone-aware

### DIFF
--- a/custom_components/digitransit/sensor.py
+++ b/custom_components/digitransit/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import UnitOfTime
-
+from zoneinfo import ZoneInfo
 from .const import DOMAIN
 from .coordinator import DigitransitDataUpdateCoordinator
 from .entity import DigitransitEntity
@@ -64,12 +64,13 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
     @property
     def extra_state_attributes(self):
         """Attributes contain a list of the next few departures."""
+        timezone = ZoneInfo(self.hass.config.time_zone)
         departure_list = (
             self.coordinator.data.get("data")
             .get("stop")
             .get("stoptimesWithoutPatterns")
         )
-        departure_list = list(map(formatDepartureRow, departure_list))
+        departure_list = [formatDepartureRow(row, timezone) for row in departure_list]
         return {"departures": departure_list}
 
     @property

--- a/custom_components/digitransit/utils.py
+++ b/custom_components/digitransit/utils.py
@@ -1,11 +1,11 @@
 """Transform data for display."""
-from datetime import datetime
+from datetime import datetime, timedelta
 import math
 
-def formatDepartureRow(row):
+def formatDepartureRow(row, timezone):
     """Simplify the departure information for use in the attribute."""
-    row['scheduledDeparture'] = datetime.fromtimestamp(row['serviceDay'] + row['scheduledDeparture'])
-    row['realtimeDeparture'] = datetime.fromtimestamp(row['serviceDay'] + row['realtimeDeparture'])
+    row['scheduledDeparture'] = datetime.fromtimestamp(row['serviceDay'], timezone) + timedelta(seconds=row['scheduledDeparture'])
+    row['realtimeDeparture'] = datetime.fromtimestamp(row['serviceDay'], timezone) + timedelta(seconds=row['realtimeDeparture'])
     row['route'] = row.pop('trip')['routeShortName']
     row.pop('serviceDay')
     return row


### PR DESCRIPTION
This PR will make departure times in sensor attributes offset-aware datetime objects. This allows much easier post-processing (with f. ex. template sensors) compared to current offset-naive implementation.

This will be a braking change but IMHO well worth it and better done now while the component is still in a beta release stage.

PS. Many thanks for a great custom component!