### PR TITLE
Pin action-gh-release to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,6 @@ jobs:
           zip digitransit.zip -r ./
 
       - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ github.workspace }}/custom_components/digitransit/digitransit.zip


### PR DESCRIPTION
The release jobs are failing (e.g. https://github.com/Mallonbacka/custom-component-digitransit/actions/runs/12619468565) due to an issue with action-gh-release, which is discussed further in https://github.com/softprops/action-gh-release/issues/556.

This pins the action to the more generic `v2` version for now, which currently points to v2.0.9 and seems to be updated less hurriedly. 