### PR TITLE
Search for stops using the Geocoding API and use Routing API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,9 @@ or tram stop, train or metro platform) from Helsinki Region Transport
 (Helsingin seudun liikenne, HSL, Helsingforsregionens trafik, HRT),
 Waltti or another Digitransit-supported region as a Home Assistant sensor.
 
-You can add a stop using either:
-
-- The stop number, which you can find on a sign at the
-stop or from the journey planner (reittiopas). For example, for trams from
-Länsiterminaali T1 going towards central Helsinki, you'd use H0236. For
-platform 1 at Tapiola bus station, you'd use E2187. This won't work if
-two stops have the same code.
-- The GTFS identifier of the stop. This is useful if two stops
-share a single stop number. You can find this URL encoded inside the address
-of the journey planner page for the stop. For example, Alberganesplanadi
-([E1112](https://reittiopas.hsl.fi/pysakit/HSL%3A2112231?locale=en))
-has the address `pysakit/HSL%3A2112231`, and the GTFS identifier `HSL:2112231` -
-swap the `%3A` for a colon.
+Search for a stop using the name or stop code. Search results will include extra
+details, like the stop code or platform number, which should allow you to tell
+them apart if there are several results.
 
 You'll also need a Digitransit API key. You can sign up for one for free
 on [the Digitransit website](https://digitransit.fi/en/developers/api-registration/).

--- a/custom_components/digitransit/config_flow.py
+++ b/custom_components/digitransit/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for Digitransit."""
+
 from __future__ import annotations
 from typing import Any
 
@@ -7,17 +8,16 @@ from homeassistant import config_entries
 from homeassistant.helpers import selector
 
 from .const import DOMAIN
+from .geocoding_client import GeocodingClient
 
 from .graphql_wrapper import (
     DigitransitGraphQLWrapper,
     DigitransitNotAuthenticatedError,
-    DigitransitMultipleStopsFoundError,
-    DigitransitNoStopFoundError
 )
 
 
 class DigitransitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Config flow for Blueprint."""
+    """Config flow for Digitransit instance."""
 
     VERSION = 2
 
@@ -27,7 +27,7 @@ class DigitransitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self,
         user_input: dict | None = None,
     ) -> config_entries.FlowResult:
-        """Handle a flow initialized by the user."""
+        """Step 1 - Handle a flow initialized by the user, collect API key."""
         _errors = {}
         if user_input is not None:
             try:
@@ -38,16 +38,30 @@ class DigitransitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 _errors["base"] = "auth"
             else:
                 self.data = {
-                    "digitransit_api_key": user_input["digitransit_api_key"]}
+                    "digitransit_api_key": user_input["digitransit_api_key"],
+                    "data_region": user_input["data_region"],
+                }
                 return await self.async_step_stop_info()
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required("digitransit_api_key", default=(user_input or {}).get("digitransit_api_key")): selector.TextSelector(
+                    vol.Required(
+                        "digitransit_api_key",
+                        default=(user_input or {}).get("digitransit_api_key", ""),
+                    ): selector.TextSelector(
                         selector.TextSelectorConfig(
                             type=selector.TextSelectorType.TEXT
+                        ),
+                    ),
+                    vol.Required(
+                        "data_region",
+                        default=(user_input or {}).get("data_region", None),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=["hsl", "waltti", "digitransit"],
+                            translation_key="data_regions",
                         ),
                     ),
                 }
@@ -59,73 +73,125 @@ class DigitransitFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self,
         user_input: dict | None = None,
     ) -> config_entries.FlowResult:
-        """Step 2 - once API key is confirmed working."""
+        """Step 2 - once API key is confirmed working, run the search."""
         _errors = {}
         if user_input is not None:
-            try:
-                stop_name, api_id = await self.identify_stop(user_input['search_type'], user_input['search_term'], user_input['data_region'])
-            except DigitransitNoStopFoundError:
+            assert self.data
+            search_results = await self.identify_stop(
+                user_input["search_term"],
+                self.data_region,
+                user_input.get("feed_id") or list(self.data["all_feeds"].keys())[0],
+            )
+            if len(search_results) == 0:
                 _errors["base"] = "no_stop_found"
-            except DigitransitMultipleStopsFoundError:
-                _errors["base"] = "too_many_stops"
             else:
-                return self.async_create_entry(
-                    title=stop_name,
-                    data=self.data | user_input | {"gtfs_id": api_id},
+                self.data = (
+                    (self.data or {}) | user_input | {"search_results": search_results}
                 )
+                return await self.async_step_select_stop(None)
 
+        assert self.data
+        self.data["all_feeds"] = await self.all_feeds(
+            self.data["digitransit_api_key"], self.data["data_region"]
+        )
+        select_options = [
+            selector.SelectOptionDict(label=label, value=feed_id)
+            for feed_id, label in self.data["all_feeds"].items()
+        ]
+        fields = {}
+        if len(select_options) != 1:
+            fields[
+                vol.Required(
+                    "feed_id",
+                    default=(user_input or {}).get("feed_id", None),
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=select_options,
+                ),
+            )
+        fields[
+            vol.Required(
+                "search_term", default=(user_input or {}).get("search_term", "")
+            )
+        ] = selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+        )
         return self.async_show_form(
             step_id="stop_info",
-            data_schema=vol.Schema(
-                {
-                    vol.Required("data_region", default=(user_input or {}).get("data_region")): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=["hsl", "waltti", "digitransit"],
-                            translation_key="data_regions",
-                        ),
-                    ),
-                    vol.Required("search_type", default=(user_input or {}).get("search_type")): selector.SelectSelector(
-                        selector.SelectSelectorConfig(
-                            options=["stop_code", "stop_gtfs_id"],
-                            translation_key="search_types",
-                        ),
-                    ),
-                    vol.Required("search_term", default=(user_input or {}).get("search_term")): selector.TextSelector(
-                        selector.TextSelectorConfig(
-                            type=selector.TextSelectorType.TEXT
-                        )
-                    )
-                }
-            ),
+            data_schema=vol.Schema(fields),
             errors=_errors,
         )
 
-    async def identify_stop(self, search_type, search_term, data_region):
+    async def async_step_select_stop(
+        self,
+        user_input: dict | None = None,
+    ):
+        """Step 3 - render the search results as a selectable list."""
+        if user_input is not None:
+            stop_name, gtfs_id = await self._get_stop_name_and_id_by_gtfs(
+                user_input["stop_gtfs_id"]
+            )
+            return self.async_create_entry(
+                title=stop_name,
+                data=(self.data or {}) | user_input | {"gtfs_id": gtfs_id},
+            )
+        else:
+            # Show the list
+            assert self.data
+            select_options = [
+                selector.SelectOptionDict(label=label, value=gtfs_id)
+                for gtfs_id, label in self.data["search_results"].items()
+            ]
+            return self.async_show_form(
+                step_id="select_stop",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            "stop_gtfs_id",
+                            default=(user_input or {}).get("stop_gtfs_id", None),
+                        ): selector.SelectSelector(
+                            selector.SelectSelectorConfig(
+                                options=select_options,
+                            ),
+                        )
+                    }
+                ),
+            )
+
+    async def identify_stop(self, search_term, data_region, feed_id):
         """Take the search criteria and return a stop name and code."""
         self.data_region = data_region
-        if (search_type == "stop_code"):
-            return await self._get_stop_name_and_id_by_code(search_term)
-        elif (search_type == "stop_gtfs_id"):
-            return await self._get_stop_name_and_id_by_gtfs(search_term)
-        else:
-            raise DigitransitNoStopFoundError
+        self.feed_id = feed_id
+        return await self._search_for_stop(search_term)
 
     async def _test_api_key(self, digitransit_api_key: str) -> None:
         """Validate credentials."""
         self.api_key = digitransit_api_key
         # Single-use client, as the user hasn't chosen a region yet
-        client = DigitransitGraphQLWrapper(
-            self.api_key, "hsl", hass=self.hass)
+        client = DigitransitGraphQLWrapper(self.api_key, "hsl", hass=self.hass)
         await client.test_api_key()
 
-    async def _get_stop_name_and_id_by_code(self, stop_code: str) -> str:
-        """Get the official stop name for the code."""
-        client = DigitransitGraphQLWrapper(
-            self.api_key, self.data_region, hass=self.hass)
-        return await client.get_stop_name_and_id_by_code(stop_code)
+    async def all_feeds(self, digitransit_api_key: str, data_region: str) -> dict:
+        """Get all regions."""
+        self.api_key = digitransit_api_key
+        self.data_region = data_region
+        self.client = DigitransitGraphQLWrapper(
+            self.api_key, self.data_region, hass=self.hass
+        )
+        return await self.client.all_feeds()
+
+    async def _search_for_stop(self, search_term: str) -> dict:
+        assert self.data
+        assert self.data["digitransit_api_key"]
+        client = GeocodingClient(self.data["digitransit_api_key"])
+        return await self.hass.async_add_executor_job(
+            client.search, self.feed_id, search_term
+        )
 
     async def _get_stop_name_and_id_by_gtfs(self, gtfs_id: str) -> str:
         """Get the official stop name for the code."""
         client = DigitransitGraphQLWrapper(
-            self.api_key, self.data_region, hass=self.hass)
+            self.api_key, self.data_region, hass=self.hass
+        )
         return await client.get_stop_name_and_id_by_gtfs(gtfs_id)

--- a/custom_components/digitransit/geocoding_client.py
+++ b/custom_components/digitransit/geocoding_client.py
@@ -1,0 +1,54 @@
+"""Class to wrap calls to the Geocoding API for stop search during config."""
+
+import requests
+
+SEARCH_ENDPOINT = "https://api.digitransit.fi/geocoding/v1/search"
+
+
+class GeocodingClient:
+    """REST client for Digitransit Geocoding API."""
+
+    def __init__(self, api_key):
+        """Initialize a new client with an API key."""
+        self.api_key = api_key
+
+    def search(self, feed, search_string):
+        """Search for the given string in the given feed."""
+        params = {
+            "layers": "stop",
+            "size": 5,
+            "text": search_string,
+            "sources": "gtfs" + feed,
+            "digitransit-subscription-key": self.api_key,
+        }
+        response = requests.get(SEARCH_ENDPOINT, params)
+        return {
+            self.trim_gtfs_id(feat["properties"]["id"]): self.format_label(
+                feat["properties"]
+            )
+            for feat in response.json()["features"]
+        }
+
+    def trim_gtfs_id(self, full_id):
+        """Remove the prefix and suffix from the GTFS ID."""
+        return full_id.replace("GTFS:", "").split("#")[0]
+
+    def format_label(self, properties):
+        """Add platform information or GTFS ID to label."""
+        label = properties["label"]
+        if properties["addendum"]:
+            if properties["addendum"].get("GTFS"):
+                if properties["addendum"]["GTFS"].get("platform"):
+                    label = (
+                        label
+                        + ", platform "
+                        + properties["addendum"]["GTFS"]["platform"]
+                    )
+                if properties["addendum"]["GTFS"].get("code"):
+                    if properties["addendum"]["GTFS"]["code"] not in label:
+                        label = (
+                            label + " (" + properties["addendum"]["GTFS"]["code"] + ")"
+                        )
+        else:
+            label = label + "(GTFS: " + self.trim_gtfs_id(properties["id"]) + ")"
+        return label

--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -36,11 +36,11 @@ class DigitransitGraphQLWrapper:
         """Get the right endpoint for the selected region, with the API key ready-appended."""
         match self.data_region:
             case "hsl":
-                return f"https://api.digitransit.fi/routing/v1/routers/hsl/index/graphql?digitransit-subscription-key={self.api_key}"
+                return f"https://api.digitransit.fi/routing/v2/hsl/gtfs/v1?digitransit-subscription-key={self.api_key}"
             case "waltti":
-                return f"https://api.digitransit.fi/routing/v1/routers/waltti/index/graphql?digitransit-subscription-key={self.api_key}"
+                return f"https://api.digitransit.fi/routing/v2/waltti/gtfs/v1?digitransit-subscription-key={self.api_key}"
             case "digitransit":
-                return f"https://api.digitransit.fi/routing/v1/routers/finland/index/graphql?digitransit-subscription-key={self.api_key}"
+                return f"https://api.digitransit.fi/routing/v2/finland/gtfs/v1?digitransit-subscription-key={self.api_key}"
 
     def sync_test_api_key(self):
         """Try to list feeds to see if the API key works."""
@@ -81,8 +81,8 @@ class DigitransitGraphQLWrapper:
 
     def sync_get_stop_name_and_id_by_gtfs(self, gtfs_id):
         """Find a stop name and ID from a GTFS id."""
-        query = f"""{{ stop(id: "{gtfs_id}
-                            "){{name,code,platformCode,gtfsId}}}}"""
+        query = f"""{{ stop(id: "{gtfs_id}"){{name,code,platformCode,gtfsId}}}}"""
+        LOGGER.debug(query)
         results = self.client.execute(query=query)
         if len(results["data"]["stop"]) == {}:
             # No results

--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -43,30 +43,19 @@ class DigitransitGraphQLWrapper:
                 return f"https://api.digitransit.fi/routing/v2/finland/gtfs/v1?digitransit-subscription-key={self.api_key}"
         raise Exception("Invalid data_region")
 
-    def sync_test_api_key(self):
-        """Try to list feeds to see if the API key works."""
-        query = "{feeds{feedId}}"
+    def sync_all_feeds(self):
+        """Get a list of regions and the name of the respectie publisher."""
+        query = "{feeds{feedId,publisher{name}}}"
         try:
-            LOGGER.info(query)
-            self.client.execute(query=query)
+            results = self.client.execute(query=query)
         except requests.exceptions.HTTPError as exception:
             LOGGER.warn(exception)
             raise DigitransitNotAuthenticatedError("API key rejected")
         else:
-            return True
-
-    async def test_api_key(self):
-        """Call sync_test_api_key async."""
-        return await self.hass.async_add_executor_job(self.sync_test_api_key)
-
-    def sync_all_feeds(self):
-        """Get a list of regions and the name of the respectie publisher."""
-        query = "{feeds{feedId,publisher{name}}}"
-        results = self.client.execute(query=query)
-        return {
-            feed["feedId"]: feed["publisher"]["name"]
-            for feed in results["data"]["feeds"]
-        }
+            return {
+                feed["feedId"]: feed["publisher"]["name"]
+                for feed in results["data"]["feeds"]
+            }
 
     async def all_feeds(self):
         """Call sync_all_feeds async."""

--- a/custom_components/digitransit/translations/en.json
+++ b/custom_components/digitransit/translations/en.json
@@ -4,22 +4,27 @@
             "user": {
                 "description": "You'll need a Digitransit API key to get started, get one from https://digitransit.fi",
                 "data": {
-                    "digitransit_api_key": "Digitransit API key"
+                    "digitransit_api_key": "Digitransit API key",
+                    "data_region": "Transport data provider"
                 }
             },
             "stop_info": {
-                "description": "Give the details of the stop you'd like to monitor.",
+                "description": "Search for a stop using the name or code.",
                 "data": {
-                    "data_region": "Transport provider",
-                    "search_type": "Find a stop",
-                    "search_term": "Stop code"
+                    "feed_id": "Region",
+                    "search_term": "Stop name or code"
+                }
+            },
+            "select_stop": {
+                "description": "Choose a stop from the list.",
+                "data": {
+                    "stop_gtfs_id": "Stop to monitor"
                 }
             }
         },
         "error": {
             "auth": "API key seems wrong.",
-            "no_stop_found": "Stop not found. Check that you're giving the stop code, such as H0236.",
-            "too_many_stops": "Multiple stops with the same code found. Try using the GTFS ID instead. You can find this from the journey planner URL.",
+            "no_stop_found": "Stop not found. Check your search term, and for best results, search using the stop code, such as H0236.",
             "connection": "Unable to connect to the server.",
             "unknown": "Unknown error occurred."
         }
@@ -47,12 +52,6 @@
         }
     },
     "selector": {
-        "search_types": {
-            "options": {
-                "stop_code": "by stop code (e.g. H0086)",
-                "stop_gtfs_id": "by GTFS ID (e.g. HSL:1392551 or tampere:0812)"
-            }
-        },
         "data_regions": {
             "options": {
                 "hsl": "HSL",


### PR DESCRIPTION
The current version of the API closes down in April, so it's necessary to switch to the new version. Fetching departures is unaffected and the query just works by updating the API URL. The process of finding stops by code or GTFS ID no longer works. 

Since fetching departures is unchanged, if you have a pre-configured entity, you should not notice any changes when upgrading. 

Due to the changes about searching for stops, it's necessary to re-implement the config flow. The new config flow introduces a couple of extra questions, and migrates to the Digitransit "Geocoding" API, as used by the autocomplete in the Reittiopas client. 

It's now possible to search using stop names or codes, and small typos will not affect the search results. Since many regions have similar stop names, it's not also necessary to choose a region if using the Waltti or Digitransit data (HSL is one region, so this question is skipped if using HSL). Hopefully, this makes adding a new stop easier, since it's no longer necessary to look up a stop code (in some cases). 

Since the old version of the stop search relied on V1 of the API, these changes are introduced together - splitting them up would require separate API client instances for the V1 and V2 endpoints, which seems like needless complexity. 

Fixes #105 