### PR TITLE
Fix issue where scheduled and realtime departures are an hour early

### DIFF
--- a/custom_components/digitransit/graphql_wrapper.py
+++ b/custom_components/digitransit/graphql_wrapper.py
@@ -113,6 +113,7 @@ class DigitransitGraphQLWrapper:
         try:
             query = """{ stop(id: "$stop_id") { name, vehicleMode, stoptimesWithoutPatterns { scheduledDeparture, realtimeDeparture, departureDelay, realtime, realtimeState, serviceDay, headsign, trip { routeShortName } } } }"""
             results = self.client.execute(query=query.replace("$stop_id", gtfs_id))
+            LOGGER.debug(results)
             return results
         except requests.exceptions.HTTPError as exception:
             if exception.args[0].startswith("401"):

--- a/custom_components/digitransit/utils.py
+++ b/custom_components/digitransit/utils.py
@@ -1,18 +1,26 @@
 """Transform data for display."""
-from datetime import datetime, timedelta
+
+from datetime import datetime
 import math
+
 
 def formatDepartureRow(row, timezone):
     """Simplify the departure information for use in the attribute."""
-    row['scheduledDeparture'] = datetime.fromtimestamp(row['serviceDay'], timezone) + timedelta(seconds=row['scheduledDeparture'])
-    row['realtimeDeparture'] = datetime.fromtimestamp(row['serviceDay'], timezone) + timedelta(seconds=row['realtimeDeparture'])
-    row['route'] = row.pop('trip')['routeShortName']
-    row.pop('serviceDay')
+    scheduledDepartureTimestamp = row["serviceDay"] + row["scheduledDeparture"]
+    row["scheduledDeparture"] = datetime.fromtimestamp(
+        scheduledDepartureTimestamp, timezone
+    )
+    realtimeDepartureTimestamp = row["serviceDay"] + row["realtimeDeparture"]
+    row["realtimeDeparture"] = datetime.fromtimestamp(
+        realtimeDepartureTimestamp, timezone
+    )
+    row["route"] = row.pop("trip")["routeShortName"]
+    row.pop("serviceDay")
     return row
+
 
 def departureToNumberOfMinutes(row):
     """Convert a departure into a number of minutes."""
-    departsAt = datetime.fromtimestamp(row['serviceDay'] + row['realtimeDeparture'])
+    departsAt = datetime.fromtimestamp(row["serviceDay"] + row["realtimeDeparture"])
     delta = departsAt - datetime.now()
     return math.floor(delta.total_seconds() / 60)
-


### PR DESCRIPTION
See details in #120 - due to the change in the clocks, departure times are out by one hour at present.

This also adds a tiny bit of extra debug logging, to make investigating similar issues a little easier in the future. 

Fixes #120 