### PR TITLE
Add compact_departures and shortHeadsign attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,19 @@ Then add a new integraion:
 
 ## Usage
 
-The sensor counts down to the next uncancelled departure. The attributes
-provide a list of upcoming departures with their service name and departure
-time in a machine-friendly format.
+The sensor counts down to the next uncancelled departure.
+
+The attributes are as follows:
+
+- `departures` - a list of upcoming departures from the given stop, each with the following details, mostly direct from the Digitransit API:
+  - `scheduledDeparture` - timezone-aware datetime string of the departure time according to the timetable.
+  - `realtimeDeparture` - timezone-aware datetime string of the departure time according to live information.
+  - `departureDelay` - the number of seconds late this service is running. Negative numbers indicate it is running ahead of schedule.
+  - `realtimeState` - one of `ADDED` (not present in the timetable), `CANCELED`, `MODIFIED` (the pattern has changed), `SCHEDULED` (no real-time information used), `UPDATED` (the pattern stays the same, while the times may be adjusted slightly).
+  - `headsign` - the headsign when the vehicle is at this stop.
+  - `route` - the short name of the route the vehicle is following, for example a bus number.
+  - `shortHeadsign`- if the length of `headsign` is over 15 characters, then the first word from `headsign` (e.g. "Mattby (M) via Kilo" becomes "Mattby"), otherwise the whole value of `headsign`.
+- `compact_departures` - a string, up to 28 characters long, combining the route and departure time of the next few departures. For example, `19:42 P, :47 A, :52 P` means train P departs at 19:42, followed by train A at 19:47, then P at 19:52. This is designed to display on small screens.
 
 ### Cards
 
@@ -93,6 +103,11 @@ content: >-
 ```
 
 Thanks to [@samhaa](https://github.com/samhaa) for contributing the markdown example.
+
+### Devices
+
+- To display departures on an NSPanel, see [this comment by Vitaly Repin](https://github.com/Mallonbacka/custom-component-digitransit/pull/129#issuecomment-2835639022).
+
 
 ## Credits
 

--- a/custom_components/digitransit/const.py
+++ b/custom_components/digitransit/const.py
@@ -13,3 +13,4 @@ ATTRIBUTION = "Data from Digitransit"
 
 INTERVAL = timedelta(seconds=60)
 COMPACT_DEPARTURES_CHARS = 28
+SHORT_HEADSIGN_CHARS = 15

--- a/custom_components/digitransit/const.py
+++ b/custom_components/digitransit/const.py
@@ -1,4 +1,5 @@
 """Constants for Digitransit."""
+
 from datetime import timedelta
 
 from logging import Logger, getLogger
@@ -10,4 +11,5 @@ DOMAIN = "digitransit"
 VERSION = "0.0.0"
 ATTRIBUTION = "Data from Digitransit"
 
-INTERVAL = timedelta(seconds = 60)
+INTERVAL = timedelta(seconds=60)
+COMPACT_DEPARTURES_CHARS = 28

--- a/custom_components/digitransit/sensor.py
+++ b/custom_components/digitransit/sensor.py
@@ -9,7 +9,7 @@ from .const import DOMAIN
 from .coordinator import DigitransitDataUpdateCoordinator
 from .entity import DigitransitEntity
 from .utils import (
-    formatDepartureRow,
+    format_departure_row,
     departureToNumberOfMinutes,
     list_to_compact_departures,
 )
@@ -74,7 +74,7 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
             .get("stop")
             .get("stoptimesWithoutPatterns")
         )
-        departure_list = [formatDepartureRow(row, timezone) for row in departure_list]
+        departure_list = [format_departure_row(row, timezone) for row in departure_list]
         compact_departures = list_to_compact_departures(departure_list)
         return {"departures": departure_list, "compact_departures": compact_departures}
 

--- a/custom_components/digitransit/sensor.py
+++ b/custom_components/digitransit/sensor.py
@@ -8,7 +8,11 @@ from zoneinfo import ZoneInfo
 from .const import DOMAIN
 from .coordinator import DigitransitDataUpdateCoordinator
 from .entity import DigitransitEntity
-from .utils import formatDepartureRow, departureToNumberOfMinutes
+from .utils import (
+    formatDepartureRow,
+    departureToNumberOfMinutes,
+    list_to_compact_departures,
+)
 
 ENTITY_DESCRIPTIONS = (
     SensorEntityDescription(
@@ -71,7 +75,8 @@ class DigitransitSensor(DigitransitEntity, SensorEntity):
             .get("stoptimesWithoutPatterns")
         )
         departure_list = [formatDepartureRow(row, timezone) for row in departure_list]
-        return {"departures": departure_list}
+        compact_departures = list_to_compact_departures(departure_list)
+        return {"departures": departure_list, "compact_departures": compact_departures}
 
     @property
     def icon(self):

--- a/custom_components/digitransit/sensor.py
+++ b/custom_components/digitransit/sensor.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
 class DigitransitSensor(DigitransitEntity, SensorEntity):
     """digitransit Sensor class."""
 
-    _unrecorded_attributes = frozenset({"departures"})
+    _unrecorded_attributes = frozenset({"departures", "compact_departures"})
 
     def __init__(
         self,

--- a/custom_components/digitransit/utils.py
+++ b/custom_components/digitransit/utils.py
@@ -36,7 +36,7 @@ def list_to_compact_departures(departures):
 
     prev_hour = departures[0]["realtimeDeparture"].hour
     sep = ", "
-    for departure in departures[: len(departures) - 1]:
+    for departure in departures[1 : len(departures) - 1]:
         curr_hour = departure["realtimeDeparture"].hour
         skip_hour = curr_hour == prev_hour
         next_route = departure_to_string(departure, skip_hour)

--- a/custom_components/digitransit/utils.py
+++ b/custom_components/digitransit/utils.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 import math
 
+from .const import COMPACT_DEPARTURES_CHARS
+
 
 def formatDepartureRow(row, timezone):
     """Simplify the departure information for use in the attribute."""
@@ -24,3 +26,33 @@ def departureToNumberOfMinutes(row):
     departsAt = datetime.fromtimestamp(row["serviceDay"] + row["realtimeDeparture"])
     delta = departsAt - datetime.now()
     return math.floor(delta.total_seconds() / 60)
+
+
+def list_to_compact_departures(departures):
+    """Convert the departures list to a string."""
+    if len(departures) == 0:
+        return ""
+    res = departure_to_string(departures[0])
+
+    prev_hour = departures[0]["realtimeDeparture"].hour
+    sep = ", "
+    for departure in departures[: len(departures) - 1]:
+        curr_hour = departure["realtimeDeparture"].hour
+        skip_hour = curr_hour == prev_hour
+        next_route = departure_to_string(departure, skip_hour)
+        if len(res) + len(sep) + len(next_route) <= COMPACT_DEPARTURES_CHARS:
+            res += sep + next_route
+        else:
+            break
+        prev_hour = curr_hour
+
+    return res
+
+
+def departure_to_string(departure, hide_hours=False):
+    """Convert a single departure to a string of route number + departure time."""
+    tm_str = ""
+    if not hide_hours:
+        tm_str = f"{departure["realtimeDeparture"].hour:02d}"
+    tm_str = tm_str + ":" + f"{departure["realtimeDeparture"].minute:02d}"
+    return f"{tm_str} {departure["route"]}"

--- a/custom_components/digitransit/utils.py
+++ b/custom_components/digitransit/utils.py
@@ -3,10 +3,10 @@
 from datetime import datetime
 import math
 
-from .const import COMPACT_DEPARTURES_CHARS
+from .const import COMPACT_DEPARTURES_CHARS, SHORT_HEADSIGN_CHARS
 
 
-def formatDepartureRow(row, timezone):
+def format_departure_row(row, timezone):
     """Simplify the departure information for use in the attribute."""
     scheduledDepartureTimestamp = row["serviceDay"] + row["scheduledDeparture"]
     row["scheduledDeparture"] = datetime.fromtimestamp(
@@ -17,6 +17,7 @@ def formatDepartureRow(row, timezone):
         realtimeDepartureTimestamp, timezone
     )
     row["route"] = row.pop("trip")["routeShortName"]
+    row["shortHeadsign"] = short_headsign(row["headsign"])
     row.pop("serviceDay")
     return row
 
@@ -56,3 +57,11 @@ def departure_to_string(departure, hide_hours=False):
         tm_str = f"{departure["realtimeDeparture"].hour:02d}"
     tm_str = tm_str + ":" + f"{departure["realtimeDeparture"].minute:02d}"
     return f"{tm_str} {departure["route"]}"
+
+
+def short_headsign(full_headsign):
+    """To fit into small spaces, we limit the length of this."""
+    if len(full_headsign) > SHORT_HEADSIGN_CHARS:
+        if " " in full_headsign:
+            full_headsign = full_headsign.split(" ")[0]
+    return full_headsign


### PR DESCRIPTION
This adds a new attribute to the state - compact departures. 

These are intended to be human-friendly version of the big departures object. They include the time of the departure, followed by the route number. The string will be a maximum of 28 characters, and will return an empty string if there are no departures. 

The code is closely based on the example provided by @vitalyrepin in #127 

It's possible to create a template sensor in the format that was originally requested like this:

```
template:
  - sensor:
      - name: >
          {{ state_attr("sensor.kilogarden_e1821_next_departure", "compact_departures") }}
        state: >
          {{ state_attr("sensor.kilogarden_e1821_next_departure", "departures")[0]["headsign"] }}
        icon: >
          {{ state_attr("sensor.kilogarden_e1821_next_departure", "icon") }}
```

Side-by-side, they look like this:

<img width="510" alt="Screenshot of two sensors, one with the name 20:06 114, :06 114, :22 114 and the value Mattby (M) via Kilo, and a second with the name Kilogården (E1821) next departure and the value 3 min" src="https://github.com/user-attachments/assets/5dc1ac78-96e4-4371-aba0-f7360a5fe030" />

Hopefully this solves the original problem, while keeping the solution general enough that it might be useful for others purposes, too. 

Closes #127 