### PR TITLE
Remove reliance on ContextVar in coordinator

### DIFF
--- a/custom_components/digitransit/__init__.py
+++ b/custom_components/digitransit/__init__.py
@@ -28,8 +28,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinator = DigitransitDataUpdateCoordinator(
         hass=hass,
         client=DigitransitGraphQLWrapper(
-            entry.data["digitransit_api_key"], entry.data["data_region"], route_lang, hass
+            entry.data["digitransit_api_key"],
+            entry.data["data_region"],
+            route_lang,
+            hass,
         ),
+        config_entry=entry,
     )
     # https://developers.home-assistant.io/docs/integration_fetching_data#coordinated-single-api-poll-for-data-for-all-entities
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/digitransit/coordinator.py
+++ b/custom_components/digitransit/coordinator.py
@@ -24,6 +24,7 @@ class DigitransitDataUpdateCoordinator(DataUpdateCoordinator):
         self,
         hass: HomeAssistant,
         client: DigitransitGraphQLWrapper,
+        config_entry: ConfigEntry,
     ) -> None:
         """Initialize the coordinator."""
         self.client = client
@@ -32,6 +33,7 @@ class DigitransitDataUpdateCoordinator(DataUpdateCoordinator):
             logger=LOGGER,
             name=DOMAIN,
             update_interval=timedelta(minutes=1),
+            config_entry=config_entry,
         )
 
     async def _async_update_data(self):

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Digitransit",
     "filename": "digitransit.zip",
     "hide_default_branch": true,
-    "homeassistant": "2024.3.0",
+    "homeassistant": "2024.11.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
-homeassistant==2024.3.0
+homeassistant==2024.11.0
 pip>=21.0,<25.2
 ruff==0.12.3
 


### PR DESCRIPTION
Starting from version 2025.8, Home Assistant will warn about the reliance on reading the config entry from the context, which the coordinator was doing here. 

This manually passes the config entry through, when the coordinator is initialized, and removes the warning.

Note that passing the config entry this way was only supported starting from HA Core 2024.11, so this is now the minimum supported version of this component, and the hacs.json file has been updated accordingly. Note that supporting HA 2024.11 means we are still supporting Python 3.12 for now - support for 3.13 didn't arrive until HA 2024.12.